### PR TITLE
Removed length of password in serializeLoginMessage().

### DIFF
--- a/voltdb/io.go
+++ b/voltdb/io.go
@@ -75,7 +75,7 @@ func serializeLoginMessage(user string, passwd string) (msg bytes.Buffer, err er
 	if err != nil {
 		return
 	}
-	err = writeByteString(&msg, shabytes)
+	_, err = msg.Write(shabytes)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Fixes #2

I was able to pin down the problem after comparing it with the python implementation. I have tested the change with both voltdb-3.7 and voltdb-4.0.2.

Commit message is mentioning 4.0.3, but the correct version is 4.0.2.
