### PR TITLE
Fix float64 de/serialization

### DIFF
--- a/voltdb/fastserializer.go
+++ b/voltdb/fastserializer.go
@@ -3,6 +3,7 @@ package voltdb
 import (
 	"encoding/binary"
 	"io"
+	"math"
 	"time"
 )
 
@@ -166,7 +167,7 @@ func writeTimestamp(w io.Writer, t time.Time) (err error) {
 func writeFloat(w io.Writer, d float64) error {
 	var b [8]byte
 	bs := b[:8]
-	order.PutUint64(bs, uint64(d))
+	order.PutUint64(bs, math.Float64bits(d))
 	_, err := w.Write(bs)
 	return err
 }
@@ -179,7 +180,7 @@ func readFloat(r io.Reader) (float64, error) {
 		return 0, err
 	}
 	result := order.Uint64(bs)
-	return float64(result), nil
+	return math.Float64frombits(result), nil
 }
 
 func writeString(w io.Writer, d string) error {

--- a/voltdb/fastserializer_test.go
+++ b/voltdb/fastserializer_test.go
@@ -92,6 +92,18 @@ func TestWriteFloat(t *testing.T) {
 	}
 }
 
+func TestRoundTripFloat(t *testing.T) {
+	testVals := [...]float64{-100, -1, 0, 1, 100, 60.1798012160534}
+	for _, val := range testVals {
+		var b bytes.Buffer
+		writeFloat(&b, val)
+		r, _ := readFloat(&b)
+		if val != r {
+			t.Errorf("Expected %v have %v", val, r)
+		}
+	}
+}
+
 // only tests a single pure-ascii string
 func TestWriteString(t *testing.T) {
 	var b bytes.Buffer


### PR DESCRIPTION
Hi Ryan - Discovered a bug while trying to insert float64 into a FLOAT column.

Turns out both serialization and deserialization is broken, so I wrote some tests and fixed the issue by using math.Float64bits()/Float64frombits() for converting to/from uint32 after/before reading/writing the raw bytes.

Have confirmed the fix by round-tripping through a voltdb instance :)
