### PR TITLE
Fixed "makeslice: len out of range" (panic) when reading NULL string.

### DIFF
--- a/voltdb/fastserializer.go
+++ b/voltdb/fastserializer.go
@@ -149,7 +149,7 @@ func readLong(r io.Reader) (int64, error) {
 
 func readTimestamp(r io.Reader) (time.Time, error) {
 	nanoSeconds, err := readLong(r)
-	if nanoSeconds > 0 {
+	if nanoSeconds != 0 {
 		ts := time.Unix(0, nanoSeconds*int64(time.Microsecond))
 		return ts.Round(time.Microsecond), err
 	}

--- a/voltdb/fastserializer_test.go
+++ b/voltdb/fastserializer_test.go
@@ -142,6 +142,17 @@ func TestRoundTripNullTimestamp(t *testing.T) {
 	}
 }
 
+func TestRoundTripNegativeTimestamp(t *testing.T) {
+	ts := time.Unix(-10000, 0)
+
+	var b bytes.Buffer
+	writeTimestamp(&b, ts)
+	result, _ := readTimestamp(&b)
+	if result != ts {
+		t.Errorf("timestamp round trip failed, expected %s got %s", ts.String(), result.String())
+	}
+}
+
 func TestReflection(t *testing.T) {
 	var b bytes.Buffer
 	var expInt8 int8 = 5


### PR DESCRIPTION
Hi Ryan,

I stumbled upon a bug where readString() panics with "makeslice: len out of range" when it get's a NULL string from the cluster. I would prefer a simple zero value for now, as there is no support for NULL values yet.

What do you think?
## 

Regards,
Martin.
