### PR TITLE
Add I/O deadlines.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ There are missing api methods.
 
 There are missing components expected for a production client: 
 
- * The client doesn't timeout network reads or writes.
  * The client doesn't reconnect closed sockets.
  * The client doesn't provide a high level interface to connect to multiple
    nodes of a VoltDB database.

--- a/voltdb/api_test.go
+++ b/voltdb/api_test.go
@@ -2,11 +2,13 @@ package voltdb
 
 import (
 	"bytes"
+	"net"
 	"testing"
+	"time"
 )
 
 func TestCallOnClosedConn(t *testing.T) {
-	conn := Conn{nil, nil}
+	conn := new(Conn)
 	_, err := conn.Call("bad", 1, 2)
 	if err == nil {
 		t.Errorf("Expected error calling procedure on closed Conn")
@@ -44,5 +46,111 @@ func TestTableAccessors(t *testing.T) {
 	}
 	if table.RowCount() != rowCount {
 		t.Errorf("Bad RowCount()")
+	}
+}
+
+func isTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	opErr, ok := err.(*net.OpError)
+	if !ok {
+		return false
+	}
+
+	return opErr.Timeout()
+}
+
+// Note: This test takes two minutes unless "go test" are invoked with -short.
+func TestCallTimeout(t *testing.T) {
+	t.Parallel()
+
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("Unable to start listener: %s", err)
+	}
+	defer ln.Close()
+
+	errors := make(chan error)
+	go func() {
+		conn := new(Conn)
+		var err error
+		conn.tcpConn, err = net.DialTimeout("tcp", ln.Addr().String(), time.Second)
+		if err != nil {
+			errors <- err
+			return
+		}
+
+		if testing.Short() {
+			conn.SetResponseDeadline(time.Now().Add(time.Second))
+		}
+
+		_, err = conn.Call("@AdHoc", "SELECT 1")
+		errors <- err
+	}()
+
+	select {
+	case err := <-errors:
+		if !isTimeout(err) {
+			t.Errorf("Expected timeout error, got %s", err)
+		}
+	case <-time.After(callResponseWait + time.Second):
+		t.Errorf("Did not time out after expected duration.")
+	}
+}
+
+func TestDialTimeout(t *testing.T) {
+	t.Parallel()
+
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("Unable to start listener: %s", err)
+	}
+	defer ln.Close()
+
+	errors := make(chan error)
+	go func() {
+		_, err := NewConnection("", "", "10.255.255.1:21212")
+		errors <- err
+	}()
+
+	select {
+	case err := <-errors:
+		if !isTimeout(err) {
+			t.Errorf("Expected timeout error, got %s", err)
+		}
+	case <-time.After(connectWait + time.Second):
+		t.Error("NewConnection did not time out after expected duration.")
+	}
+
+}
+
+func TestLoginTimeout(t *testing.T) {
+	t.Parallel()
+
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("Unable to start listener: %s", err)
+	}
+	defer ln.Close()
+
+	errors := make(chan error)
+	go func() {
+		_, err := NewConnection("", "", ln.Addr().String())
+		errors <- err
+	}()
+
+	// Accept a connection, but don't read/write. Should result in a timeout *net.OpError.
+	conn, _ := ln.Accept()
+	defer conn.Close()
+
+	select {
+	case err := <-errors:
+		if !isTimeout(err) {
+			t.Errorf("Expected a timeout error, got %s", err)
+		}
+	case <-time.After(loginResponseWait + time.Second):
+		t.Error("NewConnection did not time out after expected duration.")
 	}
 }


### PR DESCRIPTION
Hi Ryan!

I have finally got the opportunity to do some work on this package again :)

This pull request holds the first of several commits working towards adding a higher level interface for connecting to multiple nodes in a VoltDB cluster. I think it is reasonable to divide the work into multiple pull requests, each one implementing isolated features needed for the higher level interface.

But if you prefer, I will be happy to append all those commits to this request.

---

This adds read/write deadline on every read/write call to Conn.tcpConn,
and also uses the DialTimeout function to bring up the connection.

The new method SetResponseDeadline provide the means of overriding
the default call response deadline.

The tcpConn is now a net.Conn (was *net.TCPConn), as we were only using
the methods from net.Conn and DialTimeout returns this interface.

For your convenience:
- Dial deadline: 5 seconds.
- Login response deadline: 1 second.
- Call response deadline: 2 minutes (as java client default).
- Ping response deadline: 1 second.
- Write deadline: 1 second.
